### PR TITLE
Issue 26 - fix setup to install the module correctly

### DIFF
--- a/test/test_pso.py
+++ b/test/test_pso.py
@@ -2,7 +2,8 @@
 # pylint: disable=E1101
 import unittest
 import numpy as np
-import pso
+#from psopy import Candidate, solver
+import psopy.pso as pso
 
 
 class CandidateHelper(pso.Candidate):


### PR DESCRIPTION
The **init** file was missing. Also, the test was not importing the
correct file. Both issue are now fixed.
